### PR TITLE
Added `number-of-hours` as an input value

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Closes pull requests with the specified label that are older than 23 hours.
 
 **Required** GitHub Token with repo scope.
 
+### `numnber-of-hours`
+
+**Required** The number of hours beyond which a PR is considered stale at runtime.
+
 ### `label-name`
 
 **Required** The label of PRs to evaluate for closing.
@@ -24,5 +28,6 @@ id: close-stale-issues
 uses: MobilityData/github-action-close-stale-prs@main
 with:
     github-token: ${{ env.CREDENTIALS }}
+    numnber-of-hours: 23
     label-name: 'automated-content-update'
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Closes pull requests with the specified label that are older than 23 hours.
 
 **Required** GitHub Token with repo scope.
 
-### `numnber-of-hours`
+### `number-of-hours`
 
 **Required** The number of hours beyond which a PR is considered stale at runtime.
 

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
   github-token: # id of output
     description: 'GitHub Token with repo scope.'
     required: true
-  numnber-of-hours: # id of output
+  number-of-hours: # id of output
     description: 'The number of hours beyond which a PR is considered stale at runtime.'
     required: true
   label-name: # id of output

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   github-token: # id of output
     description: 'GitHub Token with repo scope.'
     required: true
+  numnber-of-hours: # id of output
+    description: 'The number of hours beyond which a PR is considered stale at runtime.'
+    required: true
   label-name: # id of output
     description: 'The label of PRs to evaluate for closing.'
     required: true

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const github = require('@actions/github');
 async function closeStalePullRequests() {
   try {
     const token = core.getInput('github-token');
-    const numbeOfHours = core.getInput('numnber-of-hours');
+    const numberOfHours = core.getInput('number-of-hours');
     const label = core.getInput('label-name');
     const octokit = new github.getOctokit(token);
 
@@ -21,7 +21,7 @@ async function closeStalePullRequests() {
 
     const now = new Date();
     const hourInMs = 60 * 60 * 1000;
-    const closeThreshold = parseInt(numbeOfHours) * hourInMs; // The number of hours beyond which a PR is considered stale at runtime.
+    const closeThreshold = parseInt(numberOfHours) * hourInMs; // The number of hours beyond which a PR is considered stale at runtime.
 
     // Check each pull request
     for (const pullRequest of response.data) {

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const github = require('@actions/github');
 async function closeStalePullRequests() {
   try {
     const token = core.getInput('github-token');
+    const numbeOfHours = core.getInput('numnber-of-hours');
     const label = core.getInput('label-name');
     const octokit = new github.getOctokit(token);
 
@@ -20,7 +21,7 @@ async function closeStalePullRequests() {
 
     const now = new Date();
     const hourInMs = 60 * 60 * 1000;
-    const closeThreshold = 23 * hourInMs; // 23 hours
+    const closeThreshold = parseInt(numbeOfHours) * hourInMs; // The number of hours beyond which a PR is considered stale at runtime.
 
     // Check each pull request
     for (const pullRequest of response.data) {


### PR DESCRIPTION
To specify the number of hours beyond which a PR is considered stale at runtime.